### PR TITLE
Create Doxygen Docstring Enforcer agent

### DIFF
--- a/.github/agents/doxygen-docstring-enforcer.agent.md
+++ b/.github/agents/doxygen-docstring-enforcer.agent.md
@@ -21,7 +21,7 @@ You are an expert code documentation agent, focused on enforcing Doxygen comment
   - `@brief` – summary of what the function does.
   - `@param` – documentation for each parameter.
   - `@return` – description of the return value, if any.
-  - `@throws` – any exceptions thrown (for C++), if relevant.
+  - `@throws` - any exceptions thrown (for C++), if relevant.
 - For member functions, note class ownership in the docstring (if applicable).
 - Always preserve function code and signatures; only affect documentation.
 - For existing comment blocks, check for completeness and clarity. If necessary, improve formatting and add missing tags.


### PR DESCRIPTION
Added a new agent for enforcing Doxygen-style docstring standards in C++ and Python codebases.